### PR TITLE
Apply tooltip to modded beehives as well

### DIFF
--- a/common/src/main/java/net/anvian/bee_info/mixin/TooltipMixin.java
+++ b/common/src/main/java/net/anvian/bee_info/mixin/TooltipMixin.java
@@ -6,10 +6,11 @@ import net.minecraft.nbt.ListTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
 import net.minecraft.world.item.TooltipFlag;
+import net.minecraft.world.level.block.BeehiveBlock;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -34,7 +35,7 @@ public abstract class TooltipMixin {
     @Inject(method = "getTooltipLines", at = @At("RETURN"), locals = LocalCapture.CAPTURE_FAILHARD)
     private void getTooltipdone(Player playerIn, TooltipFlag advanced, CallbackInfoReturnable<List> ci, List<Component> list) {
         try {
-            if (!this.isEmpty() && (this.getItem() == Items.BEEHIVE || this.getItem() == Items.BEE_NEST)) {
+            if (!this.isEmpty() && this.getItem() instanceof BlockItem bi && bi.getBlock() instanceof BeehiveBlock) {
                 CompoundTag tag = this.getTag();
                 if (tag != null) {
                     int honeyLevel = tag.getCompound("BlockStateTag").getInt("honey_level");


### PR DESCRIPTION
Note: doesn't build due to anvians_lib not having all versions on the maven or not at the paths the build files expect, but that's the same for a fresh clone; I had to build it locally and pull from maven local, and then still the paths weren't all equal (ignoring the loader of course), so I left all that out of the PR.

Content wise, don't hardcode the beehive and bee nest, but check for their common beehiveblock class instead, similar to what you're doing on 1.20.6+

Relevant issue: #3 